### PR TITLE
Fix the build

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,8 +27,6 @@ jobs:
               tox-env: 'py27-extra'
             - python-version: '3.6'
               tox-env: 'py36-extra'
-            - python-version: '3.6'
-              tox-env: 'py36-legacy'
             - python-version: '3.7'
               tox-env: 'py37-nodeps'
             - python-version: '3.6'

--- a/_ci/runtests_default_with_crfsuite.sh
+++ b/_ci/runtests_default_with_crfsuite.sh
@@ -5,7 +5,6 @@ py.test --doctest-modules \
         --ignore eli5/lightgbm.py \
         --ignore eli5/catboost.py \
         --ignore eli5/keras \
-        --ignore eli5/sklearn_crfsuite \
         --ignore eli5/formatters/image.py \
         --ignore tests/utils_image.py \
         --cov=eli5 --cov-report=html --cov-report=term  "$@"

--- a/_ci/runtests_extra.sh
+++ b/_ci/runtests_extra.sh
@@ -8,4 +8,5 @@ py.test --doctest-modules \
         --ignore tests/test_sklearn_vectorizers.py \
         --ignore tests/test_utils.py \
         --ignore eli5/lightning.py \
+        --ignore eli5/sklearn_crfsuite \
         --cov=eli5 --cov-report=html --cov-report=term "$@"

--- a/constraints-test.txt
+++ b/constraints-test.txt
@@ -1,1 +1,3 @@
 numpy>=1.14.3
+tensorflow<2.0
+Keras<=2.3.1

--- a/docs/source/libraries/keras.rst
+++ b/docs/source/libraries/keras.rst
@@ -8,6 +8,8 @@ Keras_ is "a high-level neural networks API, written in Python and capable of ru
 Keras can be used for many Machine Learning tasks, and it has support for both popular
 and experimental neural network architectures.
 
+Note: only TensorFlow 1.x is supported, recommended Keras version is 2.3.1 or earlier.
+
 .. _Keras: https://keras.io/
 
 

--- a/eli5/base_utils.py
+++ b/eli5/base_utils.py
@@ -12,7 +12,6 @@ except ImportError:
     from singledispatch import singledispatch  # type: ignore
 
 
-
 def attrs(class_):
     """ Like attr.s with slots=True,
     but with attributes extracted from __init__ method signature.

--- a/tests/test_sklearn_crfsuite.py
+++ b/tests/test_sklearn_crfsuite.py
@@ -51,7 +51,7 @@ def test_sklearn_crfsuite(xseq, yseq):
     assert '<th>rainy</th><th>sunny</th>' in html_nospaces
 
     try:
-        from eli5 import format_as_dataframe, format_as_dataframes
+        from eli5 import format_as_dataframes
     except ImportError:
         pass
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-; this is a tox config for running ELI5 tests
+; This is a tox config for running ELI5 tests
 ; under all supported Python interpreters.
 
 ; Building LightGBM may require additional system-level dependencies
@@ -6,7 +6,8 @@
 ; https://github.com/Microsoft/LightGBM/tree/master/python-package#lightgbm-python-package.
 
 [tox]
-envlist = py27,py35,py35-nodeps,mypy,py35-extra,py27-extra,py36,py36-extra,py36-legacy,py37-nodeps
+; if adding or removing an environment, please also update .github/workflows/python-package.yml
+envlist = py27,py35,py35-nodeps,mypy,py35-extra,py27-extra,py36,py36-extra,py37-nodeps
 
 [base]
 deps=
@@ -62,13 +63,6 @@ commands=
     ; run tests for extra dependencies
     bash _ci/runtests_extra.sh {posargs: eli5 tests}
 
-[testenv:py36-legacy]
-commands=
-    pip install "scipy < 1.0.0"
-    pip install "scikit-learn < 0.19"
-    pip install "numpy < 1.14"
-    pip install "xgboost == 0.6a2"
-    {[testenv]commands}
 
 [testenv:py36-extra]
 basepython=python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ deps=
 whitelist_externals = /bin/bash
 deps=
     {[base]deps}
-    sklearn-crfsuite
     ipython
     pandas
 
@@ -34,6 +33,18 @@ commands=
     pip install joblib "sklearn-contrib-lightning >= 0.4"
     pip install -e .
     bash _ci/runtests_default.sh {posargs: eli5 tests}
+
+
+[testenv:py27]
+deps=
+    {[testenv]deps}
+    ; currently sklearn-crfsuite is not compatible with newer scikit-learn
+    sklearn-crfsuite
+commands=
+    ; to install lightning numpy must be installed first
+    pip install joblib "sklearn-contrib-lightning >= 0.4"
+    pip install -e .
+    bash _ci/runtests_default_with_crfsuite.sh {posargs: eli5 tests}
 
 
 [testenv:py35-nodeps]
@@ -68,6 +79,7 @@ commands=
 basepython=python3.6
 deps={[testenv:py35-extra]deps}
 commands={[testenv:py35-extra]commands}
+
 
 [testenv:py27-extra]
 basepython=python2.7


### PR DESCRIPTION
- drop py36-legacy, as now py27 works well enough with most libraries already dropping support for it
- restrict TF and Keras versions (we support only TF 1.x)
- test skelarn-crfsuite only under python 2.7, as it does not work with newer sklearn