### PR TITLE
fix: fixes import error when importing jinja2 > 3.0.3,

### DIFF
--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -19,9 +19,7 @@ from .trees import tree2text
 from .text_helpers import prepare_weighted_spans, PreparedWeightedSpans
 
 
-template_env = Environment(
-    loader=PackageLoader('eli5', 'templates'),
-    extensions=['jinja2.ext.with_'])
+template_env = Environment(loader=PackageLoader('eli5', 'templates'))
 template_env.globals.update(dict(zip=zip, numpy=np))
 template_env.filters.update(dict(
     weight_color=lambda w, w_range: format_hsl(weight_color_hsl(w, w_range)),

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ scipy
 singledispatch >= 3.4.0.3
 scikit-learn >= 0.20
 attrs > 16.0.0
-jinja2
+jinja2 >= 3.0.0
 pip >= 8.1
 setuptools >= 20.7

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'attrs > 17.1.0',
-        'jinja2',
+        'jinja2 >= 3.0.0',
         'numpy >= 1.9.0',
         'scipy',
         'six',


### PR DESCRIPTION
Fix: fixes import error when importing jinja2 > 3.0.3, requirements & setup are also updated.

Tested it with jinja2 = 3.0.0

Also tested it with jinja2 < 3.0.0 (2.11.3), but this resulted in an error not related to the fix. So support for the lowest possible version of jinja2 is not impacted.