### PR TITLE
fix: fix missing sampler_params attribute

### DIFF
--- a/eli5/lime/samplers.py
+++ b/eli5/lime/samplers.py
@@ -135,6 +135,7 @@ class MaskingTextSamplers(BaseSampler):
         self.random_state = random_state
         self.rng_ = check_random_state(random_state)
         self.token_pattern = token_pattern
+        self.sampler_params = sampler_params
         self.samplers = list(map(self._create_sampler, sampler_params))
         if weights is None:
             self.weights = np.ones(len(self.samplers))


### PR DESCRIPTION

fixes:#27

missing attribute will cause sklearn modules to fail even if unused/untouched. This is due to the enumeration of all params in prettyprint from sklearn.

This is mitigated by adding sampler_params attribute to the MaskingTextSamplers class.